### PR TITLE
Add reset & list subcommands for /review

### DIFF
--- a/data/data_holder.go
+++ b/data/data_holder.go
@@ -1,0 +1,12 @@
+package data
+
+import (
+	"github.com/AngelVI13/slack-assistant/device"
+	"github.com/AngelVI13/slack-assistant/users"
+)
+
+type DataHolder struct {
+	Devices   *device.DevicesMap
+	Users     *users.UsersInfo
+	Reviewers users.Reviewers
+}

--- a/slack/handlers/loop.go
+++ b/slack/handlers/loop.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/AngelVI13/slack-assistant/device"
+	"github.com/AngelVI13/slack-assistant/data"
 	"github.com/AngelVI13/slack-assistant/slack/modals"
 	"github.com/AngelVI13/slack-assistant/slack/slash"
 	"github.com/AngelVI13/slack-assistant/users"
@@ -34,14 +34,8 @@ var SlashCommandsForHandlers = map[string]slash.SlashHandler{
 	"/review": &slash.ReviewHandler{},
 }
 
-type DataHolder struct {
-	Devices   *device.DevicesMap
-	Users     *users.UsersInfo
-	Reviewers users.Reviewers
-}
-
 type SlackBot struct {
-	Data *DataHolder
+	Data *data.DataHolder
 
 	SlackClient *socketmode.Client
 	// Whenever we are dealing with a modal that contains a state switching option
@@ -159,7 +153,7 @@ func (bot *SlackBot) handleSlashCommand(command slack.SlashCommand) error {
 		return bot.handleDeviceCommand(&command, handler)
 	} else if handler, hasValue := SlashCommandsForHandlers[command.Command]; hasValue {
 		// TODO: Reviewers here is hardcoded -> need a better way to handle args for slash commands
-		return handler.Execute(&command, bot.SlackClient, &bot.Data.Reviewers)
+		return handler.Execute(&command, bot.SlackClient, bot.Data)
 	} else {
 		// NOTE: this can only happen if slack added new command but the bot was not updated to support it
 		log.Printf("WARNING: User (%s) requested unsupported command %s\n", command.UserName, command.Command)

--- a/slack/slash/review.go
+++ b/slack/slash/review.go
@@ -88,8 +88,9 @@ func getTaskLink(taskId string) (url string, errorMsg string) {
 func resetReviewers(reviewersInfo *users.Reviewers, command *slack.SlashCommand, slackClient *socketmode.Client) {
 	reviewersInfo.ResetCurrentReviewers()
 	msg := fmt.Sprintf(
-		"Reviewer list reset successfully! There are %d available reviewers.\n\n_For a full list of reviewers use *'/review list'* command._",
+		"Reviewer list reset successfully! There are %d available reviewers.\n\n_For a full list of reviewers use *'/review %s'* command._",
 		len(reviewersInfo.Current),
+		ListReviewersCmd,
 	)
 	slackClient.PostEphemeral(command.ChannelID, command.UserID, slack.MsgOptionText(msg, false))
 }

--- a/users/reviewers.go
+++ b/users/reviewers.go
@@ -34,8 +34,6 @@ func NewReviewers(config *config.Config, usersMap *UsersMap) Reviewers {
 	if errors.Is(err, os.ErrNotExist) {
 		// Load reviewers from users list and create current reviewers list file
 		reviewers.ResetCurrentReviewers()
-		reviewers.synchronizeToFile()
-
 		log.Printf("INFO: Generated reviewers list from users info (%d reviewers).", len(reviewers.All))
 	} else if err == nil {
 		// Load current reviewers from file
@@ -77,6 +75,7 @@ func (r *Reviewers) ResetCurrentReviewers() {
 	}
 
 	r.Current = currentReviewers
+	r.synchronizeToFile()
 }
 
 // ChooseReviewer Picks a reviewer from the current list of reviewers (can't be equal to sender).

--- a/utils/setup.go
+++ b/utils/setup.go
@@ -2,12 +2,12 @@ package utils
 
 import (
 	"github.com/AngelVI13/slack-assistant/config"
-	"github.com/AngelVI13/slack-assistant/slack/handlers"
+	"github.com/AngelVI13/slack-assistant/data"
 	"github.com/AngelVI13/slack-assistant/users"
 )
 
 // SetupDataHolder Loads all data sources from locations specified in config file
-func SetupDataHolder(config *config.Config) *handlers.DataHolder {
+func SetupDataHolder(config *config.Config) *data.DataHolder {
 	devicesInfo := GetDevices(config)
 	usersMap := GetUsers(config.UsersFilename)
 	usersInfo := &users.UsersInfo{
@@ -15,7 +15,7 @@ func SetupDataHolder(config *config.Config) *handlers.DataHolder {
 		Filename: config.UsersFilename,
 	}
 
-	dataHolder := &handlers.DataHolder{
+	dataHolder := &data.DataHolder{
 		Devices:   &devicesInfo,
 		Users:     usersInfo,
 		Reviewers: users.NewReviewers(config, &usersInfo.Map),


### PR DESCRIPTION
Usage:
`/review list` -> shows all available reviewers
`/review reset` -> resets all current reviewers (loads new list from All configured users (reviewers)

NOTE: these commands are only available for admins