### PR TITLE
Device ordering

### DIFF
--- a/device/device_map.go
+++ b/device/device_map.go
@@ -61,17 +61,11 @@ func (d *DevicesMap) synchronizeFromFile(data []byte) {
 // that have been reserved by provided user. Then are all the other devices
 // sorted by status (reserved or not) and then sub-sorted by name.
 func (d *DevicesMap) GetDevicesInfo(user string) DevicesInfo {
-	devices := make(DevicesInfo, 0, len(d.Devices))
-
-	for _, value := range d.Devices {
-		devices = append(devices, value)
-	}
-
 	// Group devices in 2 groups -> belonging to given user or not
 	// The group that doesn't belong to user will be sorted by name and by status (reserved or not)
 	userDevices := make(DevicesInfo, 0)
 	nonUserDevices := make(DevicesInfo, 0)
-	for _, d := range devices {
+	for _, d := range d.Devices {
 		if d.Reserved && d.ReservedBy == user {
 			userDevices = append(userDevices, d)
 		} else {
@@ -113,7 +107,7 @@ func (d *DevicesMap) GetDevicesInfo(user string) DevicesInfo {
 		})
 	}
 
-	allDevices := make(DevicesInfo, 0, len(devices))
+	allDevices := make(DevicesInfo, 0, len(d.Devices))
 	allDevices = append(allDevices, userDevices...)
 	allDevices = append(allDevices, nonUserDevices...)
 	return allDevices

--- a/slack/handlers/loop.go
+++ b/slack/handlers/loop.go
@@ -144,7 +144,7 @@ func (bot *SlackBot) ProcessMessageLoop(ctx context.Context) {
 // Crashes in case the slack client could not open model view
 func (bot *SlackBot) handleUnauthorizedUserCommand(command *slack.SlashCommand) {
 	handler := &modals.UnauthorizedHandler{}
-	modalRequest := handler.GenerateModalRequest(command, bot.Data.Devices.GetDevicesInfo())
+	modalRequest := handler.GenerateModalRequest(command, bot.Data.Devices.GetDevicesInfo(command.UserName))
 
 	_, err := bot.SlackClient.OpenView(command.TriggerID, modalRequest)
 	if err != nil {
@@ -176,7 +176,7 @@ func (bot *SlackBot) handleDeviceCommand(
 	if command.Command == "/users" {
 		data = bot.Data.Users.Map
 	} else {
-		data = bot.Data.Devices.GetDevicesInfo()
+		data = bot.Data.Devices.GetDevicesInfo(command.UserName)
 	}
 
 	// In case we are dealing with an OptionModalHandler save pointer to it
@@ -284,7 +284,12 @@ func (bot *SlackBot) handleInteractionEvent(interaction slack.InteractionCallbac
 			}
 
 			// update modal view to display changes
-			updatedView := bot.CurrentOptionModalData.Handler.GenerateModalRequest(bot.CurrentOptionModalData.Command, bot.Data.Devices.GetDevicesInfo())
+			updatedView := bot.CurrentOptionModalData.Handler.GenerateModalRequest(
+				bot.CurrentOptionModalData.Command,
+				bot.Data.Devices.GetDevicesInfo(
+					bot.CurrentOptionModalData.Command.UserName,
+				),
+			)
 			_, err := bot.SlackClient.UpdateView(updatedView, "", "", interaction.View.ID)
 			if err != nil {
 				log.Fatal(err)

--- a/slack/modals/add_user.go
+++ b/slack/modals/add_user.go
@@ -10,13 +10,13 @@ const MAddUserOptionId = "optionSelected"
 
 type AddUserHandler struct{}
 
-func (h *AddUserHandler) GenerateModalRequest(users any) slack.ModalViewRequest {
-	allBlocks := h.GenerateBlocks(users)
+func (h *AddUserHandler) GenerateModalRequest(command *slack.SlashCommand, users any) slack.ModalViewRequest {
+	allBlocks := h.GenerateBlocks(command, users)
 
 	return generateModalRequest(MAddUserTitle, allBlocks)
 }
 
-func (h *AddUserHandler) GenerateBlocks(usersM any) []slack.Block {
+func (h *AddUserHandler) GenerateBlocks(command *slack.SlashCommand, usersM any) []slack.Block {
 
 	var allBlocks []slack.Block
 

--- a/slack/modals/device_booking.go
+++ b/slack/modals/device_booking.go
@@ -18,12 +18,12 @@ const (
 
 type DeviceBookingHandler struct{}
 
-func (h *DeviceBookingHandler) GenerateModalRequest(data any) slack.ModalViewRequest {
-	allBlocks := h.GenerateBlocks(data)
+func (h *DeviceBookingHandler) GenerateModalRequest(command *slack.SlashCommand, data any) slack.ModalViewRequest {
+	allBlocks := h.GenerateBlocks(command, data)
 	return generateInfoModalRequest(MDeviceBookingTitle, allBlocks)
 }
 
-func (h *DeviceBookingHandler) GenerateBlocks(data any) []slack.Block {
+func (h *DeviceBookingHandler) GenerateBlocks(command *slack.SlashCommand, data any) []slack.Block {
 	devices, ok := data.(device.DevicesInfo)
 	if !ok {
 		log.Fatal("Expected DevicesInfo but got something else")

--- a/slack/modals/handler_interface.go
+++ b/slack/modals/handler_interface.go
@@ -6,8 +6,8 @@ import (
 
 type (
 	ModalHandler interface {
-		GenerateModalRequest(any) slack.ModalViewRequest
-		GenerateBlocks(any) []slack.Block
+		GenerateModalRequest(*slack.SlashCommand, any) slack.ModalViewRequest
+		GenerateBlocks(*slack.SlashCommand, any) []slack.Block
 	}
 
 	OptionModalHandler interface {

--- a/slack/modals/option.go
+++ b/slack/modals/option.go
@@ -36,8 +36,8 @@ func (h *CustomOptionModalHandler) Reset() {
 	h.selectedAction = h.defaultAction
 }
 
-func (h *CustomOptionModalHandler) GenerateModalRequest(data any) slack.ModalViewRequest {
-	allBlocks := h.GenerateBlocks(data)
+func (h *CustomOptionModalHandler) GenerateModalRequest(command *slack.SlashCommand, data any) slack.ModalViewRequest {
+	allBlocks := h.GenerateBlocks(command, data)
 
 	var title string
 	submition_req := false
@@ -64,7 +64,7 @@ func (h *CustomOptionModalHandler) GenerateModalRequest(data any) slack.ModalVie
 
 }
 
-func (h *CustomOptionModalHandler) GenerateBlocks(data any) []slack.Block {
+func (h *CustomOptionModalHandler) GenerateBlocks(command *slack.SlashCommand, data any) []slack.Block {
 	var allBlocks []slack.Block
 
 	// Options
@@ -96,7 +96,7 @@ func (h *CustomOptionModalHandler) GenerateBlocks(data any) []slack.Block {
 	if !ok {
 		log.Fatalf("No such action exists %s", h.selectedAction)
 	}
-	blocks := action.handler.GenerateBlocks(data)
+	blocks := action.handler.GenerateBlocks(command, data)
 	allBlocks = append(allBlocks, blocks...)
 
 	return allBlocks

--- a/slack/modals/remove_users.go
+++ b/slack/modals/remove_users.go
@@ -13,13 +13,13 @@ const MRemoveUsersOptionId = "MRemoveUsersOptionId"
 
 type RemoveUsersHandler struct{}
 
-func (h *RemoveUsersHandler) GenerateModalRequest(users any) slack.ModalViewRequest {
-	allBlocks := h.GenerateBlocks(users)
+func (h *RemoveUsersHandler) GenerateModalRequest(command *slack.SlashCommand, users any) slack.ModalViewRequest {
+	allBlocks := h.GenerateBlocks(command, users)
 
 	return generateModalRequest(MRemoveUsersTitle, allBlocks)
 }
 
-func (h *RemoveUsersHandler) GenerateBlocks(usersM any) []slack.Block {
+func (h *RemoveUsersHandler) GenerateBlocks(command *slack.SlashCommand, usersM any) []slack.Block {
 	var allBlocks []slack.Block
 
 	var userBlocks []*slack.OptionBlockObject

--- a/slack/modals/restart_proxy.go
+++ b/slack/modals/restart_proxy.go
@@ -14,12 +14,12 @@ const MRestartProxyCheckboxId = "proxyCheckbox"
 
 type RestartProxyHandler struct{}
 
-func (h *RestartProxyHandler) GenerateModalRequest(data any) slack.ModalViewRequest {
-	allBlocks := h.GenerateBlocks(data)
+func (h *RestartProxyHandler) GenerateModalRequest(command *slack.SlashCommand, data any) slack.ModalViewRequest {
+	allBlocks := h.GenerateBlocks(command, data)
 	return generateModalRequest(MRestartProxyTitle, allBlocks)
 }
 
-func (h *RestartProxyHandler) GenerateBlocks(data any) []slack.Block {
+func (h *RestartProxyHandler) GenerateBlocks(command *slack.SlashCommand, data any) []slack.Block {
 	devices, ok := data.(device.DevicesInfo)
 	if !ok {
 		log.Fatal("Expected DevicesInfo but got something else")

--- a/slack/modals/show_users.go
+++ b/slack/modals/show_users.go
@@ -14,8 +14,8 @@ const MShowUsersOptionId = "optionSelected"
 
 type ShowUsersHandler struct{}
 
-func (h *ShowUsersHandler) GenerateModalRequest(users any) slack.ModalViewRequest {
-	allBlocks := h.GenerateBlocks(users)
+func (h *ShowUsersHandler) GenerateModalRequest(command *slack.SlashCommand, users any) slack.ModalViewRequest {
+	allBlocks := h.GenerateBlocks(command, users)
 
 	return generateModalRequest(MShowUsersTitle, allBlocks)
 }
@@ -33,7 +33,7 @@ func generateSectionBlocks(users users.UsersMap) []*slack.SectionBlock {
 	return userBlocks
 }
 
-func (h *ShowUsersHandler) GenerateBlocks(usersM any) []slack.Block {
+func (h *ShowUsersHandler) GenerateBlocks(command *slack.SlashCommand, usersM any) []slack.Block {
 	var allBlocks []slack.Block
 
 	usersMap, ok := usersM.(users.UsersMap)


### PR DESCRIPTION
* Add command (slack.SlashCommand) parameter to ModalHandler interface. This is needed in order to do user specific sorting of displayed values inside modal.
* Add special ordering of devices in GetDevicesInfo() which prioritizes the devices the requesting user has reserved.

NOTE: currently the slash command parameter to modal handler interfaces is not needed. Initially i had it there, then i removed, this PR is adding it back in. I have a feeling we might need this so lets keep this in the code. If in the next few releases it is still not used then we can remove it (again .. 😆 ) .